### PR TITLE
Repara bug para que no aparezca la palabra años

### DIFF
--- a/src/components/Testimonios.jsx
+++ b/src/components/Testimonios.jsx
@@ -99,7 +99,8 @@ export default function Testimonios(props) {
               <CardContent>
                 <Typography variant="h5">{testimonio.nombre}</Typography>
                 <Typography variant="subtitle1">
-                  {testimonio.edad} años - {testimonio.localidad}
+                  {testimonio.edad ? `${testimonio.edad} años - ` : ''}
+                  {testimonio.localidad}
                 </Typography>
                 <Typography variant="subtitle2">{testimonio.puesto}</Typography>
               </CardContent>


### PR DESCRIPTION
Repara bug en la palabra años para que cuando los testimonios no contengan la edad la palabra años no aparezca vacía